### PR TITLE
Modify plugin to allow the use of variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,25 @@
-module.exports = function({ e, addUtilities, config }) {
-  let newUtilities = {}
-  let margins = config('theme.margin', {})
-  
-  for (const key in margins) {
-    let className = `.${e(`o-${key}`)} > * + *`
-    let marginTop = margins[key]
+module.exports = function() {
+  return ({ theme, variants, e, config, addUtilities }) => {
+    const defaultCssOwlsTheme = {};
+    const defaultCssOwlsVariants = ["responsive"];
 
-    if (marginTop == 'auto') {
-      continue
+    const cssOwlsTheme = theme("cssOwls", defaultCssOwlsTheme);
+    const cssOwlVariants = variants("cssOwls", defaultCssOwlsVariants);
+
+    let cssOwlUtilities = {};
+    let margins = config("theme.margin", {});
+
+    for (const key in margins) {
+      let className = `.${e(`o-${key}`)} > * + *`;
+      let marginTop = margins[key];
+
+      if (marginTop == "auto") {
+        continue;
+      }
+
+      cssOwlUtilities[className] = { marginTop };
     }
 
-    newUtilities[className] = {marginTop}
-  }
-
-  addUtilities(newUtilities)
-}
+    addUtilities(cssOwlUtilities, cssOwlVariants);
+  };
+};


### PR DESCRIPTION
Establishes a theme name of `cssOwls` to use in the config. By default, the plugin's theme uses the `responsive` variant, but will accept others, as well. Synthesized from this plugin and https://github.com/webdna/tailwindcss-aspect-ratio